### PR TITLE
Add service and action file extensions

### DIFF
--- a/rosmsg.sublime-syntax
+++ b/rosmsg.sublime-syntax
@@ -3,6 +3,8 @@
 name: ROS msg
 file_extensions:
   - msg
+  - srv
+  - action
 scope: source.rosmsg
 variables:
   built_in_types: 'bool|int8|uint8|int16|uint16|int32|uint32|int64|uint64|float32|float64|string|time|duration'


### PR DESCRIPTION
Add service and action file extensions (.srv and .action) to enable highlighting for their corresponding interfaces.